### PR TITLE
Fix Typo

### DIFF
--- a/plugins/webcam/views/settings.jade
+++ b/plugins/webcam/views/settings.jade
@@ -3,7 +3,7 @@ div.container
   h2 Webcam
   p The plugin requires&nbsp;
     code streamer
-    | &nbsp;or&nbso;
+    | &nbsp;or&nbsp;
     code motion 
     | &nbsp;to capture images from your webcam. To install it, run one of the following command on your Raspberry PI console:
   pre sudo apt-get install streamer


### PR DESCRIPTION
Beyond minor, but a typo here that causes the text "&nbso;" to show up on webcam setup page.
