### PR TITLE
fix the initial state for gpio toggles when accessing through api

### DIFF
--- a/plugins/gpio/index.js
+++ b/plugins/gpio/index.js
@@ -124,10 +124,13 @@ define([ 'pi-gpio' ], function(gpio) {
      * GET
      */
     if (req.method == 'GET') {
+      var that = this;
       this.app.get('db').collection(this.collection, function(err, collection) {
         collection.find({}).toArray(function(err, items) {
           if (!err) {
-            res.send(200, items);
+            that.beforeRender(items, function() {
+              res.send(200, items);
+            });
           } else {
             res.send(500, '[]');
           }


### PR DESCRIPTION
apply the before render function to toggles before returning, otherwise the initial state of toggles is wrong. 
