### PR TITLE
repo field added to npm pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "heimcontrol.js",
   "version": "0.0.1",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ni-c/heimcontrol.js.git"
+  },
   "scripts": {
     "start": "node heimcontrol.js"
   },


### PR DESCRIPTION
fixes the warning during `npm install` (doesn't actually make any difference)
