### PR TITLE
Warn & continue if Arduino serial connection open fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ping": "= 0.1.7",
     "wake_on_lan": "= 0.0.3",
     "delivery": "= 0.0.3",
-    "duino": "https://github.com/ni-c/duino/tarball/master",
+    "duino": "tjanson/duino#gracefulish-detectconnect",
     "piswitch": "^1.0.3"
   }
 }

--- a/plugins/arduino/index.js
+++ b/plugins/arduino/index.js
@@ -19,7 +19,17 @@ define([ 'duino' ], function(duino) {
 
     this.app = app;
     this.id = this.name.toLowerCase();
+
     this.board = new duino.Board();
+    // this.board.debug = true;
+    function warnNoDuino(e) {
+        console.warn("[WARNING] error while trying to connect to Arduino:")
+        console.warn(" >>> " + e);
+        console.info("[INFO] continuing and hoping for the best...");
+        // FIXME: we should disable this plugin in some way, though
+    }
+    this.board.on('error', warnNoDuino);
+    this.board.setup();
 
     this.pins = {};
     this.pluginHelper = app.get('plugin helper');


### PR DESCRIPTION
Many users have run into the "cannot open /dev/" error message that so far occurs when the `duino` serial connection cannot be established.
That message isn't quite self-explanatory, and it's not obvious why an Arduino should be strictly required in the first place.

Now:
- a meaningful warning is displayed
- Heimcontrol does not quit immediately (though it's possible that it'll crash down the road if something expects the Arduino Board to be present; this could be improved further)

In other words, you can finally run Heimcontrol without an Arduino.

~~Depends on ni-c/duino#4.~~ Actually doesn't, uses my fork instead. This can be changed if the PR is accepted.
Fixes #64, #50, #12 & many similar.
