### PR TITLE
Don't crash on request without cookies (redirect to login instead) (fixes #76)

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -449,8 +449,11 @@ define([ 'crypto', 'cookie', 'fs' ], function(crypto, cookie, fs) {
         if (r.length == 0) {
           return res.redirect('/register');
         } else {
-          var c = cookie.parse(req.headers.cookie);
-          if ((!err) && (c.email) && (c.password)) {
+	  var c = null;
+	  if (typeof req.headers.cookie !== 'undefined') {
+            c = cookie.parse(req.headers.cookie);
+          }
+          if ((!err) && c && c.email && c.password) {
             return Controller.doLogin(req, res);
           } else {
             return res.render('login', {


### PR DESCRIPTION
When handling a request without cookies, i.e., with
`typeof req.headers.cookie === 'undefined'`, detect the problem and redirect to
login rather than crashing.
Fixes #76.
