### PR TITLE
Exclude plugins through config

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -6,5 +6,8 @@
     "name" : "heimcontroljs",
     "port" : "27017",
     "user" : {}
+  },
+  "plugins": { 
+  	"exclude": [] 
   }
 }

--- a/heimcontrol.js
+++ b/heimcontrol.js
@@ -173,7 +173,7 @@ requirejs([ 'http', 'connect', 'mongodb', 'path', 'express', 'node-conf', 'socke
         // 404 Not found
         app.all('*', Routes.notFound);
 
-      });
+      }, config.plugins.exclude);
     }
   });
 });

--- a/libs/PluginHelper.js
+++ b/libs/PluginHelper.js
@@ -47,11 +47,19 @@ define([ 'fs' ], function( fs ) {
    * @param {String} callback.err null if no error occured, otherwise the error
    * @param {Object} callback.result An array containing the plugins
    */
-  PluginHelper.prototype.getPluginList = function(callback) {
+  PluginHelper.prototype.getPluginList = function(callback, excludes) {
     var pluginList = [];
     var that = this;
     var files = fs.readdirSync(that.pluginFolder);
     var requirejs = require('requirejs');
+
+    // Remove excluded plugins from the files list
+    for(key in excludes) {
+      var plugin = excludes[key];
+      var index = files.indexOf(plugin);
+      if( index > -1)
+          files.splice(index, 1);
+    }
 
     function requireRecursive(files) {
       var file = files.shift(); // results in alphabetical order


### PR DESCRIPTION
When I tried to run the heimcontrol app on my computer it would not start because of a dependency in piswitch called "wiring-pi", which seems to only build on pi I think.

So using this new configuration option you can just disable plugins you don't need or disable the plugins that don't work on your platform. 
The advantage of this is that you can now also run Heimcontrol on other platforms like a regular *nix server.

How do you guys test your new code? Do you always test you code on the pi itself? 